### PR TITLE
:sparkles:Feat: Change Admin Page of Exhibitions

### DIFF
--- a/exhibitions/admin.py
+++ b/exhibitions/admin.py
@@ -1,4 +1,32 @@
 from django.contrib import admin
 from .models import Exhibition
+from accompanies.models import Accompany
 
-admin.site.register(Exhibition)
+
+class AccompanyInline(admin.TabularInline):
+    model = Accompany
+    readonly_fields = (
+        "content",
+        "user",
+        "personnel",
+        "start_time",
+        "end_time",
+    )
+    show_change_link = True
+
+
+@admin.register(Exhibition)
+class ExhibitionAdmin(admin.ModelAdmin):
+    list_display = [
+        "category",
+        "info_name",
+        "location",
+        "start_time",
+        "end_time",
+    ]
+    list_display_links = ["info_name"]
+
+    inlines = [AccompanyInline]
+
+
+# admin.site.register(Exhibition)


### PR DESCRIPTION
어드민페이지 전시회 목록에 카테고리, 전시회 이름, 장소, 전시 시작 날짜,
종료 날짜가 보이게 수정했습니다.
각 전시회 게시글 수정창에 게시글에 달린 동행 구하기 댓글이 읽기전용으로 보이도록
했습니다 변경 버튼을 누르면 해당 댓글 편집창으로 이동합니다