### PR TITLE
:bug:Fix: 전시회 모델 필드명 변경에 따른 어드민 수정사항

### DIFF
--- a/exhibitions/admin.py
+++ b/exhibitions/admin.py
@@ -21,8 +21,8 @@ class ExhibitionAdmin(admin.ModelAdmin):
         "category",
         "info_name",
         "location",
-        "start_time",
-        "end_time",
+        "start_date",
+        "end_date",
     ]
     list_display_links = ["info_name"]
 


### PR DESCRIPTION
전시회 모델에 start_time, end_time이 start_date, end_date로 변경된 게 반영된 줄 모르고 PR 보냈네요
admin.py에도 변경된 필드명으로 바꿨습니다