### PR TITLE
:sparkles:Feat:회원가입 시 비밀번호 재확인 기능 추가

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -8,8 +8,8 @@ from users.models import User
 
 
 class UserCreationForm(forms.ModelForm):
-    password1 = forms.CharField(label="Password", widget=forms.PasswordInput)
-    password2 = forms.CharField(
+    password = forms.CharField(label="Password", widget=forms.PasswordInput)
+    password_check = forms.CharField(
         label="Password confirmation", widget=forms.PasswordInput
     )
 
@@ -19,16 +19,16 @@ class UserCreationForm(forms.ModelForm):
             "email",
         ]
 
-    def clean_password2(self):  # passworld가 일치하는지 확인하는 것
-        password1 = self.cleaned_data.get("password1")
-        password2 = self.cleaned_data.get("password2")
-        if password1 and password2 and password1 != password2:
+    def clean_password_check(self):  # passworld가 일치하는지 확인하는 것
+        password = self.cleaned_data.get("password")
+        password_check = self.cleaned_data.get("password_check")
+        if password and password_check and password != password_check:
             raise ValidationError("Passwords don't match")
-        return password2
+        return password_check
 
     def save(self, commit=True):
         user = super().save(commit=False)
-        user.set_password(self.cleaned_data["password1"])
+        user.set_password(self.cleaned_data["password"])
         if commit:
             user.save()
         return user
@@ -58,7 +58,7 @@ class UserAdmin(BaseUserAdmin):
             None,
             {
                 "classes": ["wide"],
-                "fields": ["email", "password1", "password2"],
+                "fields": ["email", "password", "password_check"],
             },
         ),
     ]

--- a/users/views.py
+++ b/users/views.py
@@ -10,8 +10,15 @@ from users.models import User
 class UserView(APIView):
     def post(self, request):
         """회원 가입을 실행합니다."""
+        password = request.data["password"]
+        password_check = request.data["password_check"]
         serializer = UserSerializer(data=request.data)
-        if serializer.is_valid():
+        if password != password_check:
+            return Response(
+                {"message": "재확인 비밀번호가 일치하지 않습니다."},
+                status=status.HTTP_406_NOT_ACCEPTABLE,
+            )
+        elif serializer.is_valid():
             serializer.save()
             return Response(
                 {"message": "회원가입이 완료되었습니다."}, status=status.HTTP_201_CREATED


### PR DESCRIPTION
비밀번호 재확인 기능을 추가하였습니다.
사용자 회원가입 시 두 개의 인풋태그로 비밀번호를 입력받은 후
두 비밀번호가 서로 일치하는지 확인합니다.

메인 비밀번호의 변수명은 password 이고
체크용 비밀번호의 변수명은 password_check 입니다.
**users/admin.py 에서도 같은 이름체계로 수정했습니다.

두 비밀번호가 일치하지 않으면 안내메시지와 함께
HTTP_406_NOT_ACCEPTABLE 상태를 반환합니다.

두 비밀번호가 일치하면 평소처럼 정상적인 serialization 단계를 거쳐
회원가입하게 됩니다.