### PR TITLE
:sparkles:Feat:마이페이지 기능 추가 #11

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from rest_framework import serializers
 from users.models import User
+from datetime import datetime, date
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -33,3 +34,15 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
         token["is_admin"] = user.is_admin
 
         return token
+
+
+class UserMypageSerializer(serializers.ModelSerializer):
+    since_together = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = ("nickname", "bio", "created_at", "since_together", "profile_image")
+
+    def get_since_together(self, request_user):
+        calculate = date.today() - request_user.created_at.date()
+        return calculate.days

--- a/users/urls.py
+++ b/users/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     path("signin/", views.CustomTokenObtainPairView.as_view(), name="user_signin"),
     path("", views.UserDetailView.as_view(), name="user_update_and_delete"),
     path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
+    path("<int:user_id>/", views.UserMypageView.as_view(), name="UserMypageView"),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -3,7 +3,12 @@ from rest_framework import status
 from rest_framework import permissions
 from rest_framework.response import Response
 from rest_framework_simplejwt.views import TokenObtainPairView
-from users.serializers import CustomTokenObtainPairSerializer, UserSerializer
+from users.serializers import (
+    CustomTokenObtainPairSerializer,
+    UserSerializer,
+    UserMypageSerializer,
+)
+from rest_framework.generics import get_object_or_404
 from users.models import User
 
 
@@ -52,3 +57,12 @@ class UserDetailView(APIView):
         user.is_active = False
         user.save()
         return Response({"message": "탈퇴되었습니다."})
+
+
+# 마이페이지
+class UserMypageView(APIView):
+    def get(self, request, user_id):
+        user = get_object_or_404(User, id=user_id)
+        serializer = UserMypageSerializer(user)
+
+        return Response(serializer.data)


### PR DESCRIPTION
마이페이지 보기 GET 요청에 대한 기능이 추가되었습니다.
사용자가 /api/users/<int:user_id> 경로로 접근 시
user_id 값이 지칭하는 회원의 마이페이지 데이터가 로드됩니다.

이번 업데이트에서는
1. 사용자 닉네임
2. 사용자 자기소개
3. 가입일
4. 가입일로부터 우리와 함께한 시간
5. 프로필 이미지 정보가 로드됩니다.

내가 좋아요한 전시회 정보는 추후 업데이트에서 추가할 예정