### PR TITLE
:sparkles:Feat: 비슷한 전시회 추천 기능 구현 #74"

### DIFF
--- a/exhibitions/recommend_ml.py
+++ b/exhibitions/recommend_ml.py
@@ -1,0 +1,53 @@
+import psycopg2, os
+import pandas as pd
+import numpy as np
+from sklearn.feature_extraction.text import CountVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+
+# 데이터베이스 연결
+con = psycopg2.connect(
+    host=os.environ.get("DB_HOST"),
+    dbname=os.environ.get("DB_NAME"),
+    user=os.environ.get("DB_USER"),
+    password=os.environ.get("DB_PASSWORD"),
+    port=os.environ.get("DB_PORT"),
+)
+cur = con.cursor()
+cur.execute("SELECT id, info_name, location, category From exhibitions_exhibition")
+cols = [column[0] for column in cur.description]
+exhibition_df = pd.DataFrame.from_records(data=cur.fetchall(), columns=cols)
+con.close()  # 데이터베이스 연결 종료
+
+# info_name별 유사도 측정
+count_vect = CountVectorizer(min_df=0, ngram_range=(1, 2))
+info_name_mat = count_vect.fit_transform(exhibition_df["info_name"])
+
+# 유사도 행렬 생성
+info_name_sim = cosine_similarity(info_name_mat, info_name_mat)
+
+
+# 특정 정보와 서비스명 유사도가 높은 서비스 정보를 얻기 위한 함수 생성
+def recommendation(id, top_n=10):
+    # 입력한 정보의 index
+    target_info_name = exhibition_df[exhibition_df["id"] == id]
+    target_index = target_info_name.index.values
+
+    # 입력한 정보의 유사도 데이터 프레임 추가
+    exhibition_df["similarity"] = info_name_sim[target_index, :].reshape(-1, 1)
+
+    # 유사도 내림차순 정렬 후 상위 index 추출
+    temp = exhibition_df.sort_values(by=["similarity"], ascending=False)
+    temp = temp[temp.index.values != target_index]  # 자기 자신 제거
+
+    final_index = temp.index.values[:top_n]
+    raw_exhibitions = exhibition_df.iloc[final_index]
+    # print(raw_exhibitions)
+    ml_recommend_exhibitions_id_list = list(
+        np.array(raw_exhibitions[["id"]]["id"].tolist())
+    )
+
+    return ml_recommend_exhibitions_id_list
+
+
+# print(recommendation(5885))

--- a/exhibitions/serializers.py
+++ b/exhibitions/serializers.py
@@ -13,7 +13,6 @@ class ExhibitionSerializer(serializers.ModelSerializer):
             "id",
             "user_id",
             "info_name",
-            "content",
             "location",
             "image",
             "created_at",
@@ -39,6 +38,7 @@ class ExhibitionDetailSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         # serializer.data
         data = super().to_representation(instance)
+        data["recommend"] = self.context["recommend"]
         pagination = CustomPageNumberPagination()
         # query_params
         select = self.context["select"]


### PR DESCRIPTION
전시회 상세보기 조회 시 해당 전시회와 비슷한 전시회 10개를 recommend라는
필드에서 확인 가능합니다.
recommend_ml.py의 recommend()함수에서 전시회의 id를 받아 해당 전시회의 제목을 기준으로 비슷한 제목을 가진 상위 10개의 전시회 id를 반환합니다.
반환된 추천 전시회 id 리스트로 views.py에서는 전시회 정보를 가져오고
serializers.py에서 직렬화하여 보여줍니다.