### PR TITLE
:bug:Fix: admin페이지에서 회원 수정 시 생기는 에러 수정

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -41,16 +41,19 @@ class UserChangeForm(forms.ModelForm):  # user update할 때 사용하는 form
         model = User
         fields = ["email", "password", "is_active", "is_admin"]
 
+    def clean_password(self):
+        return self.initial["password"]
+
 
 class UserAdmin(BaseUserAdmin):
     form = UserChangeForm
     add_form = UserCreationForm
 
-    list_display = ["email", "is_admin"]
+    list_display = ["email", "is_admin", "is_active"]
     list_filter = ["is_admin"]
     fieldsets = [
         (None, {"fields": ["email", "password"]}),
-        ("Permissions", {"fields": ["is_admin"]}),
+        ("Permissions", {"fields": ["is_admin", "is_active"]}),
     ]
 
     add_fieldsets = [


### PR DESCRIPTION
1. 회원탈퇴한 회원의 계정을 다시 살릴 수 있도록 is_active 필드를 permissions에 추가함
2. 회원의 관리자 여부, 활성화 여부를 수정하고 저장하면 비밀번호가 바뀌어서 다시 로그인 할 수 없는 에러가 있어서 회원 정보 수정 시 원래 비밀번호를 그대로 유지하게끔 수정함