### PR TITLE
:bug:Fix: 새 전시회 등록 시 나타나는 서버 에러 수정 #98

### DIFF
--- a/exhibitions/recommend_ml.py
+++ b/exhibitions/recommend_ml.py
@@ -6,32 +6,30 @@ from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
 
-# 데이터베이스 연결
-con = psycopg2.connect(
-    host=os.environ.get("DB_HOST"),
-    dbname=os.environ.get("DB_NAME"),
-    user=os.environ.get("DB_USER"),
-    password=os.environ.get("DB_PASSWORD"),
-    port=os.environ.get("DB_PORT"),
-)
-cur = con.cursor()
-cur.execute(
-    "SELECT id, info_name, location, category, start_date, end_date, svstatus From exhibitions_exhibition"
-)
-cols = [column[0] for column in cur.description]
-exhibition_df = pd.DataFrame.from_records(data=cur.fetchall(), columns=cols)
-con.close()  # 데이터베이스 연결 종료
-
-# info_name별 유사도 측정
-count_vect = CountVectorizer(min_df=0, ngram_range=(1, 2))
-info_name_mat = count_vect.fit_transform(exhibition_df["info_name"])
-
-# 유사도 행렬 생성
-info_name_sim = cosine_similarity(info_name_mat, info_name_mat)
-
-
-# 특정 정보와 서비스명 유사도가 높은 서비스 정보를 얻기 위한 함수 생성
+# 특정 정보와 서비스명 유사도가 높은 서비스 정보를 얻기 위한 함수
 def recommendation(id, top_n=10):
+    # 데이터베이스 연결
+    con = psycopg2.connect(
+        host=os.environ.get("DB_HOST"),
+        dbname=os.environ.get("DB_NAME"),
+        user=os.environ.get("DB_USER"),
+        password=os.environ.get("DB_PASSWORD"),
+        port=os.environ.get("DB_PORT"),
+    )
+    cur = con.cursor()
+    cur.execute(
+        "SELECT id, info_name, location, category, start_date, end_date, svstatus From exhibitions_exhibition"
+    )
+    cols = [column[0] for column in cur.description]
+    exhibition_df = pd.DataFrame.from_records(data=cur.fetchall(), columns=cols)
+    con.close()  # 데이터베이스 연결 종료
+
+    # info_name별 유사도 측정
+    count_vect = CountVectorizer(min_df=0, ngram_range=(1, 2))
+    info_name_mat = count_vect.fit_transform(exhibition_df["info_name"])
+
+    # 유사도 행렬 생성
+    info_name_sim = cosine_similarity(info_name_mat, info_name_mat)
     # 입력한 정보의 index
     target_info_name = exhibition_df[exhibition_df["id"] == id]
     target_index = target_info_name.index.values


### PR DESCRIPTION
새 전시회 등록 시 recommendation 함수는 등록 이전 데이터베이스를 참고
하고 있어 상세 게시글이 조회되지 않는 에러가 있었습니다.
recommendation 함수 안에 데이터베이스 연결 부분을 넣음으로써
해결했습니다.