### PR TITLE
Feature/exhibitions

### DIFF
--- a/exhibitions/seoulweather.py
+++ b/exhibitions/seoulweather.py
@@ -1,0 +1,15 @@
+from django.http import JsonResponse
+import requests
+from decouple import config
+
+
+def get_weather(request):
+    API_KEY = config("WEATHER_API_KEY")
+    SEOUL_URL = (
+        f"https://api.openweathermap.org/data/2.5/weather?q=Seoul&appid={API_KEY}&units=metric"
+    )
+
+    response = requests.get(SEOUL_URL)
+    data = response.json()
+
+    return JsonResponse(data)

--- a/exhibitions/urls.py
+++ b/exhibitions/urls.py
@@ -1,11 +1,10 @@
 from django.urls import path
-from exhibitions import views
+from exhibitions import views, seoulweather
 
 app_name = "exhibitions"
 
 urlpatterns = [
     path("", views.ExhibitionView.as_view(), name="exhibition"),
-
     path("search/", views.ExhibitionSearchView.as_view(), name="search"),
     path(
         "<int:exhibition_id>/",
@@ -17,4 +16,5 @@ urlpatterns = [
         views.ExhibitionLikeView.as_view(),
         name="exhibition-like",
     ),
+    path("weather/", seoulweather.get_weather, name="get_seoul_weather"),
 ]


### PR DESCRIPTION
날씨 API를 불러오는 seoulweather.py가 새로이 생성되었고,exhibitions/urls.py 에 변경사항이 있습니다.

날씨 API의 키는 환경변수 처리되어 슬랙으로 공유드리겠습니다.

json으로 데이터를 보고 싶으시다면 runserver 하신뒤 /api/exhibitions/weather/
경로에서 확인 가능합니다.