### PR TITLE
:package:Package: python-decouple 추가

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ threadpoolctl==3.1.0
 typing_extensions==4.6.3
 tzdata==2023.3
 urllib3==2.0.3
+python-decouple==3.8


### PR DESCRIPTION
os만으로 import시켜서환경변수 처리된  API_KEY를 가져오려고했으나
API_KEY가 환경변수 처리가 안되어서 decouple을 사용하였는데
os.environ.get 방식이 더 올바른거 같습니다.
일단 사용하신는데 문제 없게 pr 보내고 다시금 수정해두겠습니다.