### PR TITLE
:bug:Fix: 리뷰 작성/수정 함수에 is_valid 용법에 맞게 수정 #19 #20

### DIFF
--- a/reviews/views.py
+++ b/reviews/views.py
@@ -26,13 +26,12 @@ class ReviewView(APIView):
             )
 
         serializer = ReviewSerializer(data=request.data)
-        if serializer.is_valid(raise_exception=True):
-            serializer.save(exhibition_id=exhibition_id, user=request.user)
-            return Response(
-                {"message": "리뷰가 등록되었습니다.", "data": serializer.data},
-                status=status.HTTP_201_CREATED,
-            )
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        serializer.is_valid(raise_exception=True)
+        serializer.save(exhibition_id=exhibition_id, user=request.user)
+        return Response(
+            {"message": "리뷰가 등록되었습니다.", "data": serializer.data},
+            status=status.HTTP_201_CREATED,
+        )
 
 
 class ReviewDetailView(APIView):
@@ -41,14 +40,12 @@ class ReviewDetailView(APIView):
         review = get_object_or_404(Review, id=review_id)
         if request.user == review.user:
             serializer = ReviewSerializer(review, data=request.data, partial=True)
-            if serializer.is_valid(raise_exception=True):
-                serializer.save()
-                return Response(
-                    {"message": "리뷰가 수정되었습니다.", "data": serializer.data},
-                    status=status.HTTP_200_OK,
-                )
-            else:
-                return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            serializer.is_valid(raise_exception=True)
+            serializer.save()
+            return Response(
+                {"message": "리뷰가 수정되었습니다.", "data": serializer.data},
+                status=status.HTTP_200_OK,
+            )
         else:
             return Response({"message": "권한이 없습니다."}, status=status.HTTP_403_FORBIDDEN)
 

--- a/reviews/views.py
+++ b/reviews/views.py
@@ -26,15 +26,13 @@ class ReviewView(APIView):
             )
 
         serializer = ReviewSerializer(data=request.data)
-        if serializer.is_valid():
+        if serializer.is_valid(raise_exception=True):
             serializer.save(exhibition_id=exhibition_id, user=request.user)
             return Response(
                 {"message": "리뷰가 등록되었습니다.", "data": serializer.data},
                 status=status.HTTP_201_CREATED,
             )
-        return Response(
-            {"message": "요청이 올바르지 않습니다."}, status=status.HTTP_400_BAD_REQUEST
-        )
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
 class ReviewDetailView(APIView):


### PR DESCRIPTION
리뷰 수정 함수에 시리얼라이저 is_valid에 raise_exception 옵션이 있고
valid error 시 serializer.errors를 반환하도록 되어 있어서 작성 함수에도 똑같이 raise_exception = True 옵션을 주고, valid error 시
serializer.errors만을 반환하도록 수정했습니다.