### PR TITLE
:hammer:Refact: 추천 함수 실행시간 단축 #142

### DIFF
--- a/exhibitions/recommend_ml.py
+++ b/exhibitions/recommend_ml.py
@@ -6,8 +6,7 @@ from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
 
-# 특정 정보와 서비스명 유사도가 높은 서비스 정보를 얻기 위한 함수
-def recommendation(id, top_n=5):
+def pre_processing():
     # 데이터베이스 연결
     con = psycopg2.connect(
         host=os.environ.get("DB_HOST"),
@@ -18,11 +17,15 @@ def recommendation(id, top_n=5):
     )
     cur = con.cursor()
     cur.execute(
-        "SELECT id, info_name, location, category, start_date, end_date, svstatus From exhibitions_exhibition"
+        "SELECT id, info_name, start_date, end_date, svstatus From exhibitions_exhibition"
     )
     cols = [column[0] for column in cur.description]
+
+    # 데이터프레임 생성
     exhibition_df = pd.DataFrame.from_records(data=cur.fetchall(), columns=cols)
-    con.close()  # 데이터베이스 연결 종료
+
+    # 데이터베이스 연결 종료
+    con.close()
 
     # info_name별 유사도 측정
     count_vect = CountVectorizer(min_df=0, ngram_range=(1, 2))
@@ -31,31 +34,52 @@ def recommendation(id, top_n=5):
     # 유사도 행렬 생성
     info_name_sim = cosine_similarity(info_name_mat, info_name_mat)
 
-    # 입력한 정보의 index
-    target_info_name = exhibition_df[exhibition_df["id"] == id]
-    target_index = target_info_name.index.values
+    return exhibition_df, info_name_sim
 
-    # 입력한 정보의 유사도 데이터 프레임 추가
-    exhibition_df["similarity"] = info_name_sim[target_index, :].reshape(-1, 1)
 
-    # start_date가 오늘 날짜 이전이거나 오늘이고, end_date가 오늘 날짜거나 오늘 날짜 이후인 데이터만 추출하기
-    today = datetime.date.today()
-    period = (exhibition_df["start_date"] <= today) & (
-        exhibition_df["end_date"] >= today
-    )
-    filterd_exhibition_df = exhibition_df.loc[period].sort_values(
-        by=["end_date"], ascending=True
-    )
+exhibition_df, info_name_sim = pre_processing()
 
-    # 필터링 된 데이터프레임의 유사도 내림차순 정렬 후 상위 index 추출
-    temp = filterd_exhibition_df.sort_values(by=["similarity"], ascending=False)
-    temp = temp[temp.index.values != target_index]  # 자기 자신 제거
-    temp = temp[temp["svstatus"] == "접수중"]  # svstatus가 접수중인 데이터만 추출하기
 
-    final_index = temp.index.values[:top_n]
+# 비슷한 전시 추천 시스템 함수
+def recommendation(id, top_n=5):
+    # 전역변수를 참조하도록 지정함
+    global exhibition_df
+    global info_name_sim
+
+    try:
+        # 입력한 정보의 index
+        target = exhibition_df[exhibition_df["id"] == id]
+        target_index = target.index.values
+
+        # 데이터프레임에 입력한 정보의 유사도 추가
+        exhibition_df["similarity"] = info_name_sim[target_index, :].reshape(-1, 1)
+
+        # start_date가 오늘 날짜 이전이거나 오늘이고, end_date가 오늘 날짜거나 오늘 날짜 이후인 데이터만 추출하기
+        today = datetime.date.today()
+        period = (exhibition_df["start_date"] <= today) & (
+            exhibition_df["end_date"] >= today
+        )
+        filterd_exhibition_df = exhibition_df.loc[period].sort_values(
+            by=["end_date"], ascending=True
+        )
+
+        # 날짜 필터링 된 데이터프레임의 유사도 내림차순 정렬 후 상위 index 추출
+        temp = filterd_exhibition_df.sort_values(by=["similarity"], ascending=False)
+
+        # svstatus가 접수중인 데이터만 추출
+        temp = temp[temp["svstatus"] == "접수중"]
+
+        # 데이터프레임 기준 최종 유사도 Top5 index 리스트
+        final_index = temp.index.values[:top_n]
+
+    except ValueError:
+        exhibition_df, info_name_sim = pre_processing()
+        return recommendation(id, top_n)
+
+    # 최종 유사도 Top5의 데이터프레임
     raw_exhibitions = filterd_exhibition_df.loc[final_index]
-    ml_recommend_exhibitions_id_list = list(
-        np.array(raw_exhibitions[["id"]]["id"].tolist())
-    )
+
+    # 최종 유사도 Top5의 데이터베이스 상 id 리스트
+    ml_recommend_exhibitions_id_list = np.array(raw_exhibitions[["id"]]["id"].tolist())
 
     return ml_recommend_exhibitions_id_list


### PR DESCRIPTION
데이터 전처리 부분과 추천 함수로 나누어 서버 실행 시 데이터베이스에 접속해 데이터를 가져오도록 했고, 기존 데이터 조회하는 경우와 새로운 데이터 수동 등록 후 조회하는 경우로 나눠
수동 등록 후 조회하는 경우에 데이터베이스에서 데이터를 다시 불러오도록 코드를 수정했습니다.

이 수정으로 추천 함수 실행시간이 기존 133ms에서 11ms로 10배 이상 단축되었습니다.